### PR TITLE
Fix compiler warnings

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define CL_TARGET_OPENCL_VERSION 220
+
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
 #else
@@ -47,7 +49,7 @@ int main(void) {
     cl_context context = clCreateContext( NULL, 1, &device_id, NULL, NULL, &ret);
 
     // Create a command queue
-    cl_command_queue command_queue = clCreateCommandQueue(context, device_id, 0, &ret);
+    cl_command_queue command_queue = clCreateCommandQueueWithProperties(context, device_id, 0, &ret);
 
     // Create memory buffers on the device for each vector 
     cl_mem a_mem_obj = clCreateBuffer(context, CL_MEM_READ_ONLY, 


### PR DESCRIPTION
When running `make` with the original source file, I got the following warnings:

```
In file included from /usr/include/CL/cl.h:32,
                 from main.c:7:
/usr/include/CL/cl_version.h:34:9: note: #pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)
   34 | #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
      |         ^~~~~~~
main.c: In function ‘main’:
main.c:50:5: warning: ‘clCreateCommandQueue’ is deprecated [-Wdeprecated-declarations]
   50 |     cl_command_queue command_queue = clCreateCommandQueue(context, device_id, 0, &ret);
      |     ^~~~~~~~~~~~~~~~
In file included from main.c:7:
/usr/include/CL/cl.h:1781:1: note: declared here
 1781 | clCreateCommandQueue(cl_context                     context,
      | ^~~~~~~~~~~~~~~~~~~~
```

I resolved them by specifying an explicit OpenCL version and replacing the deprecated `clCreateCommandQueue` call with the [equivalent](https://stackoverflow.com/a/28500846/451391) `clCreateCommandQueueWithProperties`.